### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
-node_modules/
-node_modules/*
+npm-debug.log


### PR DESCRIPTION
Não há necessidade de por tantas especificações no .gitignore, basta apenas digitar o nome da pasta e ela será ignorada! Também não é interessante deixar explícito o log do npm, também adicionei uma nova linha para ignorá-lo. 
