### PR TITLE
Atribuindo mais boas práticas do mongoose

### DIFF
--- a/back/config/db.js
+++ b/back/config/db.js
@@ -18,4 +18,15 @@ db.on('disconnected', function(err){
     console.log('Desconectado')
 });
 
+db.on('error',function (err) {
+  console.log('Erro de padrão de conexão do Mongoose: ' + err);
+});
+
+process.on ('SIGINT', function () {
+  db.close (function () {
+    console.log ('conexão Mongoose desconectada através de término do node CRTL + C');
+    process.exit (0);
+  });
+});
+
 module.exports = db;


### PR DESCRIPTION
Seguindo as boas práticas do mongoose vi a necessidade de colocar o evento 'error' e tratar a conexão com o banco quando pararmos a aplicação